### PR TITLE
Set standalone_app_name for Java agent

### DIFF
--- a/contrast/contrast_security-template.yaml
+++ b/contrast/contrast_security-template.yaml
@@ -6,7 +6,9 @@ api:
 application:
   name: "Agent Performance - $LANG - $FRAMEWORK"
   metadata: appID="Agent Performance - $LANG - $FRAMEWORK"
-agent: 
+agent:
+  java:
+    standalone_app_name: "Agent Performance - $LANG - $FRAMEWORK"
   service: 
     logger: 
       path: contrast_service.log


### PR DESCRIPTION
The agent won't do route discovery without it!