### PR TITLE
Update runner to use Go 1.16

### DIFF
--- a/frameworks/Go/go-std/go-pgx-contrast-assess.dockerfile
+++ b/frameworks/Go/go-std/go-pgx-contrast-assess.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14
+FROM golang:1.16
 
 ENV GO111MODULE on
 WORKDIR /go-std
@@ -15,6 +15,8 @@ COPY contrast_security.yaml /etc/contrast/contrast_security.yaml
 
 ENV CONTRAST__ASSESS__ENABLE=true
 ENV CONTRAST__PROTECT__ENABLE=false
+
+RUN chmod 777 ./contrast-go
 # End Contrast Additions
 
 RUN go generate ./templates

--- a/frameworks/Go/go-std/go-pgx-contrast-off.dockerfile
+++ b/frameworks/Go/go-std/go-pgx-contrast-off.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14
+FROM golang:1.16
 
 ENV GO111MODULE on
 WORKDIR /go-std
@@ -15,6 +15,8 @@ COPY contrast_security.yaml /etc/contrast/contrast_security.yaml
 
 ENV CONTRAST__ASSESS__ENABLE=false
 ENV CONTRAST__PROTECT__ENABLE=false
+
+RUN chmod 777 ./contrast-go
 # End Contrast Additions
 
 RUN go generate ./templates

--- a/frameworks/Go/go-std/go-pgx-contrast-protect.dockerfile
+++ b/frameworks/Go/go-std/go-pgx-contrast-protect.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14
+FROM golang:1.16
 
 ENV GO111MODULE on
 WORKDIR /go-std
@@ -15,6 +15,8 @@ COPY contrast_security.yaml /etc/contrast/contrast_security.yaml
 
 ENV CONTRAST__ASSESS__ENABLE=false
 ENV CONTRAST__PROTECT__ENABLE=true
+
+RUN chmod 777 ./contrast-go
 # End Contrast Additions
 
 RUN go generate ./templates


### PR DESCRIPTION
The Go agent requires Go 1.15 or later, for agent versions 1.0 and later.