### PR TITLE
Update rails config to match mainline, and get contrast-agent.gem install working

### DIFF
--- a/frameworks/Ruby/rails/rails-contrast-assess.dockerfile
+++ b/frameworks/Ruby/rails/rails-contrast-assess.dockerfile
@@ -1,18 +1,21 @@
-# Ruby Contrast Agent doesn't support 3.0 yet
-FROM ruby:2.7
+FROM ruby:3.0
 
-ENV BUNDLE_WITHOUT=mysql
-ENV RAILS_ENV=production_postgresql
-ENV PORT=8080
+RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends redis-server
 
 EXPOSE 8080
 WORKDIR /rails
 
 COPY ./Gemfile* /rails/
 
+ENV BUNDLE_WITHOUT=mysql
+RUN bundle config set force_ruby_platform true
 RUN bundle install --jobs=8
 
 COPY . /rails/
+
+ENV RAILS_ENV=production_postgresql
+ENV PORT=8080
+ENV REDIS_URL=redis://localhost:6379/0/cache
 
 # Start Contrast Additions
 COPY contrast-agent.gem contrast-agent.gem
@@ -26,4 +29,4 @@ run bundle exec gem install ./contrast-agent.gem --platform ruby
 RUN bundle add contrast-agent
 # End Contrast Additions
 
-CMD ["rails", "server"]
+CMD ./run-with-redis.sh

--- a/frameworks/Ruby/rails/rails-contrast-off.dockerfile
+++ b/frameworks/Ruby/rails/rails-contrast-off.dockerfile
@@ -1,18 +1,21 @@
-# Ruby Contrast Agent doesn't support 3.0 yet
-FROM ruby:2.7
+FROM ruby:3.0
 
-ENV BUNDLE_WITHOUT=mysql
-ENV RAILS_ENV=production_postgresql
-ENV PORT=8080
+RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends redis-server
 
 EXPOSE 8080
 WORKDIR /rails
 
 COPY ./Gemfile* /rails/
 
+ENV BUNDLE_WITHOUT=mysql
+RUN bundle config set force_ruby_platform true
 RUN bundle install --jobs=8
 
 COPY . /rails/
+
+ENV RAILS_ENV=production_postgresql
+ENV PORT=8080
+ENV REDIS_URL=redis://localhost:6379/0/cache
 
 # Start Contrast Additions
 COPY contrast-agent.gem contrast-agent.gem
@@ -26,4 +29,4 @@ run bundle exec gem install ./contrast-agent.gem --platform ruby
 RUN bundle add contrast-agent
 # End Contrast Additions
 
-CMD ["rails", "server"]
+CMD ./run-with-redis.sh

--- a/frameworks/Ruby/rails/rails-contrast-protect.dockerfile
+++ b/frameworks/Ruby/rails/rails-contrast-protect.dockerfile
@@ -1,18 +1,21 @@
-# Ruby Contrast Agent doesn't support 3.0 yet
-FROM ruby:2.7
+FROM ruby:3.0
 
-ENV BUNDLE_WITHOUT=mysql
-ENV RAILS_ENV=production_postgresql
-ENV PORT=8080
+RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends redis-server
 
 EXPOSE 8080
 WORKDIR /rails
 
 COPY ./Gemfile* /rails/
 
+ENV BUNDLE_WITHOUT=mysql
+RUN bundle config set force_ruby_platform true
 RUN bundle install --jobs=8
 
 COPY . /rails/
+
+ENV RAILS_ENV=production_postgresql
+ENV PORT=8080
+ENV REDIS_URL=redis://localhost:6379/0/cache
 
 # Start Contrast Additions
 COPY contrast-agent.gem contrast-agent.gem
@@ -26,4 +29,4 @@ run bundle exec gem install ./contrast-agent.gem --platform ruby
 RUN bundle add contrast-agent
 # End Contrast Additions
 
-CMD ["rails", "server"]
+CMD ./run-with-redis.sh


### PR DESCRIPTION
According to Harold, setting `bundle config set force_ruby_platform true` should be fine to do.
