### PR TITLE
SDET-988: Undo testing config

### DIFF
--- a/contrast/benchmark-variables.sh
+++ b/contrast/benchmark-variables.sh
@@ -1,3 +1,3 @@
 export CONCURRENCY_LEVELS="32 128 512"
 export DURATION=30
-export TAG="contrast-new"
+export TAG="contrast"

--- a/frameworks/Java/servlet/benchmark_config.json
+++ b/frameworks/Java/servlet/benchmark_config.json
@@ -102,7 +102,7 @@
       "display_name": "servlet",
       "notes": "",
       "versus": "servlet-raw",
-      "tags": ["contrast-new", "contrast-unattached"]
+      "tags": ["contrast", "contrast-unattached"]
     },
     "postgresql-contrast-off": {
       "db_url": "/db",
@@ -125,7 +125,7 @@
       "display_name": "servlet",
       "notes": "",
       "versus": "servlet-raw",
-      "tags": ["contrast-new", "contrast-off"]
+      "tags": ["contrast", "contrast-off"]
     },
     "postgresql-contrast-assess": {
       "db_url": "/db",
@@ -148,7 +148,7 @@
       "display_name": "servlet",
       "notes": "",
       "versus": "servlet-raw",
-      "tags": ["contrast-new", "contrast-assess"]
+      "tags": ["contrast", "contrast-assess"]
     },
     "postgresql-contrast-protect": {
       "db_url": "/db",
@@ -171,7 +171,7 @@
       "display_name": "servlet",
       "notes": "",
       "versus": "servlet-raw",
-      "tags": ["contrast-new", "contrast-protect"]
+      "tags": ["contrast", "contrast-protect"]
     },
     "postgresql-contrast-both": {
       "db_url": "/db",
@@ -194,7 +194,7 @@
       "display_name": "servlet",
       "notes": "",
       "versus": "servlet-raw",
-      "tags": ["contrast-new", "contrast-both"]
+      "tags": ["contrast", "contrast-both"]
     }
   }]
 }


### PR DESCRIPTION
Accidentally left in the test config for SDET-988, this PR removes those.