### PR TITLE
QE-948: Upgrade Go images to 1.18

### DIFF
--- a/frameworks/Go/gin/gin-scratch-contrast-assess.dockerfile
+++ b/frameworks/Go/gin/gin-scratch-contrast-assess.dockerfile
@@ -1,5 +1,5 @@
 # build layer
-FROM golang:1.16-alpine as builder
+FROM golang:1.18-alpine as builder
 
 WORKDIR /gin
 ENV GO111MODULE=on

--- a/frameworks/Go/gin/gin-scratch-contrast-off.dockerfile
+++ b/frameworks/Go/gin/gin-scratch-contrast-off.dockerfile
@@ -1,5 +1,5 @@
 # build layer
-FROM golang:1.16-alpine as builder
+FROM golang:1.18-alpine as builder
 
 WORKDIR /gin
 ENV GO111MODULE=on

--- a/frameworks/Go/gin/gin-scratch-contrast-protect.dockerfile
+++ b/frameworks/Go/gin/gin-scratch-contrast-protect.dockerfile
@@ -1,5 +1,5 @@
 # build layer
-FROM golang:1.16-alpine as builder
+FROM golang:1.18-alpine as builder
 
 WORKDIR /gin
 ENV GO111MODULE=on

--- a/frameworks/Go/gin/gin-scratch-contrast-unattached.dockerfile
+++ b/frameworks/Go/gin/gin-scratch-contrast-unattached.dockerfile
@@ -1,5 +1,5 @@
 # build layer
-FROM golang:1.16-alpine as builder
+FROM golang:1.18-alpine as builder
 
 WORKDIR /gin
 ENV GO111MODULE=on

--- a/frameworks/Go/go-std/go-pgx-contrast-assess.dockerfile
+++ b/frameworks/Go/go-std/go-pgx-contrast-assess.dockerfile
@@ -1,12 +1,12 @@
-FROM golang:1.16
+FROM golang:1.18
 
 ENV GO111MODULE on
 WORKDIR /go-std
 
 COPY ./src /go-std
 
-RUN go get github.com/valyala/quicktemplate/qtc
-RUN go get -u github.com/mailru/easyjson/...
+RUN go install github.com/valyala/quicktemplate/qtc@latest
+RUN go install github.com/mailru/easyjson/...@latest
 RUN go mod download
 
 # Start Contrast Additions

--- a/frameworks/Go/go-std/go-pgx-contrast-off.dockerfile
+++ b/frameworks/Go/go-std/go-pgx-contrast-off.dockerfile
@@ -1,12 +1,12 @@
-FROM golang:1.16
+FROM golang:1.18
 
 ENV GO111MODULE on
 WORKDIR /go-std
 
 COPY ./src /go-std
 
-RUN go get github.com/valyala/quicktemplate/qtc
-RUN go get -u github.com/mailru/easyjson/...
+RUN go install github.com/valyala/quicktemplate/qtc@latest
+RUN go install github.com/mailru/easyjson/...@latest
 RUN go mod download
 
 # Start Contrast Additions

--- a/frameworks/Go/go-std/go-pgx-contrast-protect.dockerfile
+++ b/frameworks/Go/go-std/go-pgx-contrast-protect.dockerfile
@@ -1,12 +1,12 @@
-FROM golang:1.16
+FROM golang:1.18
 
 ENV GO111MODULE on
 WORKDIR /go-std
 
 COPY ./src /go-std
 
-RUN go get github.com/valyala/quicktemplate/qtc
-RUN go get -u github.com/mailru/easyjson/...
+RUN go install github.com/valyala/quicktemplate/qtc@latest
+RUN go install github.com/mailru/easyjson/...@latest
 RUN go mod download
 
 # Start Contrast Additions

--- a/frameworks/Go/go-std/go-pgx-contrast-unattached.dockerfile
+++ b/frameworks/Go/go-std/go-pgx-contrast-unattached.dockerfile
@@ -1,12 +1,12 @@
-FROM golang:1.14
+FROM golang:1.18
 
 ENV GO111MODULE on
 WORKDIR /go-std
 
 COPY ./src /go-std
 
-RUN go get github.com/valyala/quicktemplate/qtc
-RUN go get -u github.com/mailru/easyjson/...
+RUN go install github.com/valyala/quicktemplate/qtc@latest
+RUN go install github.com/mailru/easyjson/...@latest
 RUN go mod download
 
 RUN go generate ./templates


### PR DESCRIPTION
contrast-go v3.0.0 dropped support for go1.16 which most test
images were using. This change upgrades all images to go1.18
to support contrast-go's requirements.

This change also updates "go get" commands which install tools
to use "go install" instead. "go install" is the recommended
way to build and install packages, according to:
https://go.dev/doc/go1.16#go-command