### PR TITLE
Fix gin-scratch-contrast-* configuration

### DIFF
--- a/frameworks/Go/gin/gin-scratch-contrast-assess.dockerfile
+++ b/frameworks/Go/gin/gin-scratch-contrast-assess.dockerfile
@@ -10,17 +10,11 @@ RUN apk update \
     apk add --no-cache git \
     go mod download
 
-# Start Contrast Additions
+# Start Contrast Build Additions
 COPY contrast-go contrast-go
-COPY contrast_security.yaml /etc/contrast/contrast_security.yaml
-
-ENV CONTRAST__ASSESS__ENABLE=true
-ENV CONTRAST__PROTECT__ENABLE=false
-
-ENV CONTRAST__AGENT__SERVICE__BYPASS=true
 
 RUN chmod 777 ./contrast-go
-# End Contrast Additions
+# End Contrast Build Additions
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
     ./contrast-go build -tags=jsoniter -ldflags="-s -w" -o server /gin/*.go
@@ -33,6 +27,15 @@ FROM scratch as release
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /gin/server /bin/server
 COPY --from=builder /gin/templates/fortune.html /templates/fortune.html
+
+# Start Contrast Runtime Additions
+COPY contrast_security.yaml /etc/contrast/contrast_security.yaml
+
+ENV CONTRAST__ASSESS__ENABLE=true
+ENV CONTRAST__PROTECT__ENABLE=false
+
+ENV CONTRAST__AGENT__SERVICE__BYPASS=true
+# End Contrast Runtime Additions
 
 EXPOSE 8080
 

--- a/frameworks/Go/gin/gin-scratch-contrast-off.dockerfile
+++ b/frameworks/Go/gin/gin-scratch-contrast-off.dockerfile
@@ -10,17 +10,11 @@ RUN apk update \
     apk add --no-cache git \
     go mod download
 
-# Start Contrast Additions
+# Start Contrast Build Additions
 COPY contrast-go contrast-go
-COPY contrast_security.yaml /etc/contrast/contrast_security.yaml
-
-ENV CONTRAST__ASSESS__ENABLE=false
-ENV CONTRAST__PROTECT__ENABLE=false
-
-ENV CONTRAST__AGENT__SERVICE__BYPASS=true
 
 RUN chmod 777 ./contrast-go
-# End Contrast Additions
+# End Contrast Build Additions
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
     ./contrast-go build -tags=jsoniter -ldflags="-s -w" -o server /gin/*.go
@@ -33,6 +27,15 @@ FROM scratch as release
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /gin/server /bin/server
 COPY --from=builder /gin/templates/fortune.html /templates/fortune.html
+
+# Start Contrast Runtime Additions
+COPY contrast_security.yaml /etc/contrast/contrast_security.yaml
+
+ENV CONTRAST__ASSESS__ENABLE=false
+ENV CONTRAST__PROTECT__ENABLE=false
+
+ENV CONTRAST__AGENT__SERVICE__BYPASS=true
+# End Contrast Runtime Additions
 
 EXPOSE 8080
 

--- a/frameworks/Go/gin/gin-scratch-contrast-protect.dockerfile
+++ b/frameworks/Go/gin/gin-scratch-contrast-protect.dockerfile
@@ -10,17 +10,11 @@ RUN apk update \
     apk add --no-cache git \
     go mod download
 
-# Start Contrast Additions
+# Start Contrast Build Additions
 COPY contrast-go contrast-go
-COPY contrast_security.yaml /etc/contrast/contrast_security.yaml
-
-ENV CONTRAST__ASSESS__ENABLE=false
-ENV CONTRAST__PROTECT__ENABLE=true
-
-ENV CONTRAST__AGENT__SERVICE__BYPASS=true
 
 RUN chmod 777 ./contrast-go
-# End Contrast Additions
+# End Contrast Build Additions
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
     ./contrast-go build -tags=jsoniter -ldflags="-s -w" -o server /gin/*.go
@@ -33,6 +27,15 @@ FROM scratch as release
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /gin/server /bin/server
 COPY --from=builder /gin/templates/fortune.html /templates/fortune.html
+
+# Start Contrast Runtime Additions
+COPY contrast_security.yaml /etc/contrast/contrast_security.yaml
+
+ENV CONTRAST__ASSESS__ENABLE=false
+ENV CONTRAST__PROTECT__ENABLE=true
+
+ENV CONTRAST__AGENT__SERVICE__BYPASS=true
+# End Contrast Runtime Additions
 
 EXPOSE 8080
 


### PR DESCRIPTION
Previously, all gin-scratch-contrast-* images were configuring
the agent in the builder stage. The contrast-go agent does not
bake in configuration during a build. Configuration must be set
in the main layer that will run, in this case, the release layer.
