### PR TITLE
Change base image for koa-postgress

### DIFF
--- a/contrast/contrast_security-node-protect-template.yaml
+++ b/contrast/contrast_security-node-protect-template.yaml
@@ -1,5 +1,4 @@
 api:
-  enable: false
   url: $URL
   api_key: $API_KEY
   service_key: $SERVICE_KEY

--- a/frameworks/JavaScript/express/express-postgres-contrast-assess.dockerfile
+++ b/frameworks/JavaScript/express/express-postgres-contrast-assess.dockerfile
@@ -16,7 +16,7 @@ ENV CONTRAST__ASSESS__ENABLE=true
 ENV CONTRAST__PROTECT__ENABLE=false
 ENV CONTRAST__AGENT__NODE__NATIVE_INPUT_ANALYSIS=true
 
-run npm install ./node-contrast.tgz
+RUN npm install ./node-contrast.tgz
 # End Contrast Additions
 
 CMD ["node", "-r", "@contrast/agent", "postgresql-app.js"]

--- a/frameworks/JavaScript/express/express-postgres-contrast-off.dockerfile
+++ b/frameworks/JavaScript/express/express-postgres-contrast-off.dockerfile
@@ -16,7 +16,7 @@ ENV CONTRAST__ASSESS__ENABLE=false
 ENV CONTRAST__PROTECT__ENABLE=false
 ENV CONTRAST__AGENT__NODE__NATIVE_INPUT_ANALYSIS=true
 
-run npm install ./node-contrast.tgz
+RUN npm install ./node-contrast.tgz
 # End Contrast Additions
 
 CMD ["node", "-r", "@contrast/agent", "postgresql-app.js"]

--- a/frameworks/JavaScript/express/express-postgres-contrast-protect.dockerfile
+++ b/frameworks/JavaScript/express/express-postgres-contrast-protect.dockerfile
@@ -16,7 +16,7 @@ ENV CONTRAST__ASSESS__ENABLE=false
 ENV CONTRAST__PROTECT__ENABLE=true
 ENV CONTRAST__AGENT__NODE__NATIVE_INPUT_ANALYSIS=true
 
-run npm install ./node-contrast.tgz
+RUN npm install ./node-contrast.tgz
 # End Contrast Additions
 
 CMD ["node", "-r", "@contrast/agent", "postgresql-app.js"]

--- a/frameworks/JavaScript/hapi/hapi-postgres-contrast-assess.dockerfile
+++ b/frameworks/JavaScript/hapi/hapi-postgres-contrast-assess.dockerfile
@@ -16,7 +16,7 @@ ENV CONTRAST__ASSESS__ENABLE=true
 ENV CONTRAST__PROTECT__ENABLE=false
 ENV CONTRAST__AGENT__NODE__NATIVE_INPUT_ANALYSIS=true
 
-run npm install ./node-contrast.tgz
+RUN npm install ./node-contrast.tgz
 # End Contrast Additions
 
 CMD ["node", "-r", "@contrast/agent", "app.js"]

--- a/frameworks/JavaScript/hapi/hapi-postgres-contrast-off.dockerfile
+++ b/frameworks/JavaScript/hapi/hapi-postgres-contrast-off.dockerfile
@@ -16,7 +16,7 @@ ENV CONTRAST__ASSESS__ENABLE=false
 ENV CONTRAST__PROTECT__ENABLE=false
 ENV CONTRAST__AGENT__NODE__NATIVE_INPUT_ANALYSIS=true
 
-run npm install ./node-contrast.tgz
+RUN npm install ./node-contrast.tgz
 # End Contrast Additions
 
 CMD ["node", "-r", "@contrast/agent", "app.js"]

--- a/frameworks/JavaScript/hapi/hapi-postgres-contrast-protect.dockerfile
+++ b/frameworks/JavaScript/hapi/hapi-postgres-contrast-protect.dockerfile
@@ -16,7 +16,7 @@ ENV CONTRAST__ASSESS__ENABLE=false
 ENV CONTRAST__PROTECT__ENABLE=true
 ENV CONTRAST__AGENT__NODE__NATIVE_INPUT_ANALYSIS=true
 
-run npm install ./node-contrast.tgz
+RUN npm install ./node-contrast.tgz
 # End Contrast Additions
 
 CMD ["node", "-r", "@contrast/agent", "app.js"]

--- a/frameworks/JavaScript/koa/koa-postgres-contrast-assess.dockerfile
+++ b/frameworks/JavaScript/koa/koa-postgres-contrast-assess.dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.15.1-slim
+FROM node:16.14.0-slim
 
 COPY ./ ./
 
@@ -17,7 +17,7 @@ ENV CONTRAST__ASSESS__ENABLE=true
 ENV CONTRAST__PROTECT__ENABLE=false
 ENV CONTRAST__AGENT__NODE__NATIVE_INPUT_ANALYSIS=true
 
-run npm install ./node-contrast.tgz
+RUN npm install ./node-contrast.tgz
 # End Contrast Additions
 
 CMD ["node", "-r", "@contrast/agent", "app.js"]

--- a/frameworks/JavaScript/koa/koa-postgres-contrast-off.dockerfile
+++ b/frameworks/JavaScript/koa/koa-postgres-contrast-off.dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.15.1-slim
+FROM node:16.14.0-slim
 
 COPY ./ ./
 
@@ -17,7 +17,7 @@ ENV CONTRAST__ASSESS__ENABLE=false
 ENV CONTRAST__PROTECT__ENABLE=false
 ENV CONTRAST__AGENT__NODE__NATIVE_INPUT_ANALYSIS=true
 
-run npm install ./node-contrast.tgz
+RUN npm install ./node-contrast.tgz
 # End Contrast Additions
 
 CMD ["node", "-r", "@contrast/agent", "app.js"]

--- a/frameworks/JavaScript/koa/koa-postgres-contrast-protect.dockerfile
+++ b/frameworks/JavaScript/koa/koa-postgres-contrast-protect.dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.15.1-slim
+FROM node:16.14.0-slim
 
 COPY ./ ./
 
@@ -17,7 +17,7 @@ ENV CONTRAST__ASSESS__ENABLE=false
 ENV CONTRAST__PROTECT__ENABLE=true
 ENV CONTRAST__AGENT__NODE__NATIVE_INPUT_ANALYSIS=true
 
-run npm install ./node-contrast.tgz
+RUN npm install ./node-contrast.tgz
 # End Contrast Additions
 
 CMD ["node", "-r", "@contrast/agent", "app.js"]

--- a/frameworks/Python/django/django-contrast-assess.dockerfile
+++ b/frameworks/Python/django/django-contrast-assess.dockerfile
@@ -15,7 +15,7 @@ COPY contrast_security.yaml /etc/contrast/contrast_security.yaml
 ENV CONTRAST__ASSESS__ENABLE=true
 ENV CONTRAST__PROTECT__ENABLE=false
 
-run pip3 install ./contrast-agent.tar.gz
+RUN pip3 install ./contrast-agent.tar.gz
 # End Contrast Additions
 
 # Uses alternate gunicorn config

--- a/frameworks/Python/django/django-contrast-protect.dockerfile
+++ b/frameworks/Python/django/django-contrast-protect.dockerfile
@@ -15,7 +15,7 @@ COPY contrast_security.yaml /etc/contrast/contrast_security.yaml
 ENV CONTRAST__ASSESS__ENABLE=false
 ENV CONTRAST__PROTECT__ENABLE=true
 
-run pip3 install ./contrast-agent.tar.gz
+RUN pip3 install ./contrast-agent.tar.gz
 # End Contrast Additions
 
 # Uses alternate gunicorn config

--- a/frameworks/Python/flask/flask-contrast-off.dockerfile
+++ b/frameworks/Python/flask/flask-contrast-off.dockerfile
@@ -16,7 +16,7 @@ COPY contrast_security.yaml /etc/contrast/contrast_security.yaml
 ENV CONTRAST__ASSESS__ENABLE=false
 ENV CONTRAST__PROTECT__ENABLE=false
 
-run pip3 install ./contrast-agent.tar.gz
+RUN pip3 install ./contrast-agent.tar.gz
 # End Contrast Additions
 
 # Uses alternate gunicorn config

--- a/frameworks/Python/pyramid/pyramid-contrast-assess.dockerfile
+++ b/frameworks/Python/pyramid/pyramid-contrast-assess.dockerfile
@@ -17,7 +17,7 @@ COPY contrast_security.yaml /etc/contrast/contrast_security.yaml
 ENV CONTRAST__ASSESS__ENABLE=true
 ENV CONTRAST__PROTECT__ENABLE=false
 
-run pip3 install ./contrast-agent.tar.gz
+RUN pip3 install ./contrast-agent.tar.gz
 # End Contrast Additions
 
 # Uses alternate gunicorn config

--- a/frameworks/Python/pyramid/pyramid-contrast-off.dockerfile
+++ b/frameworks/Python/pyramid/pyramid-contrast-off.dockerfile
@@ -17,7 +17,7 @@ COPY contrast_security.yaml /etc/contrast/contrast_security.yaml
 ENV CONTRAST__ASSESS__ENABLE=false
 ENV CONTRAST__PROTECT__ENABLE=false
 
-run pip3 install ./contrast-agent.tar.gz
+RUN pip3 install ./contrast-agent.tar.gz
 # End Contrast Additions
 
 # Uses alternate gunicorn config

--- a/frameworks/Python/pyramid/pyramid-contrast-protect.dockerfile
+++ b/frameworks/Python/pyramid/pyramid-contrast-protect.dockerfile
@@ -17,7 +17,7 @@ COPY contrast_security.yaml /etc/contrast/contrast_security.yaml
 ENV CONTRAST__ASSESS__ENABLE=false
 ENV CONTRAST__PROTECT__ENABLE=true
 
-run pip3 install ./contrast-agent.tar.gz
+RUN pip3 install ./contrast-agent.tar.gz
 # End Contrast Additions/Alterations
 
 # Uses alternate gunicorn config

--- a/frameworks/Ruby/rails/rails-contrast-assess.dockerfile
+++ b/frameworks/Ruby/rails/rails-contrast-assess.dockerfile
@@ -25,7 +25,7 @@ COPY contrast_security.yaml /etc/contrast/contrast_security.yaml
 ENV CONTRAST__ASSESS__ENABLE=true
 ENV CONTRAST__PROTECT__ENABLE=false
 
-run bundle exec gem install ./contrast-agent.gem --platform ruby
+RUN bundle exec gem install ./contrast-agent.gem --platform ruby
 
 RUN bundle add contrast-agent
 # End Contrast Additions

--- a/frameworks/Ruby/rails/rails-contrast-off.dockerfile
+++ b/frameworks/Ruby/rails/rails-contrast-off.dockerfile
@@ -25,7 +25,7 @@ COPY contrast_security.yaml /etc/contrast/contrast_security.yaml
 ENV CONTRAST__ASSESS__ENABLE=false
 ENV CONTRAST__PROTECT__ENABLE=false
 
-run bundle exec gem install ./contrast-agent.gem --platform ruby
+RUN bundle exec gem install ./contrast-agent.gem --platform ruby
 
 RUN bundle add contrast-agent
 # End Contrast Additions

--- a/frameworks/Ruby/rails/rails-contrast-protect.dockerfile
+++ b/frameworks/Ruby/rails/rails-contrast-protect.dockerfile
@@ -25,7 +25,7 @@ COPY contrast_security.yaml /etc/contrast/contrast_security.yaml
 ENV CONTRAST__ASSESS__ENABLE=false
 ENV CONTRAST__PROTECT__ENABLE=true
 
-run bundle exec gem install ./contrast-agent.gem --platform ruby
+RUN bundle exec gem install ./contrast-agent.gem --platform ruby
 
 RUN bundle add contrast-agent
 # End Contrast Additions


### PR DESCRIPTION
Since installing the mono-repository onto a certain app requires npm v8.x or higher I've changed the base image for koa to be Node 16 instead of Node 14, similar to the other test applications we use for node-agent testing