### PR TITLE
Remove the `set -e` option in the bash script

### DIFF
--- a/contrast/benchmark-node-protect.sh
+++ b/contrast/benchmark-node-protect.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 source ./benchmark-variables.sh
 
-set -e
-
 cd "${0%/*}"
 
 # Use files in the script directory by default

--- a/contrast/benchmark-node.sh
+++ b/contrast/benchmark-node.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 source ./benchmark-variables.sh
 
-set -e
-
 cd "${0%/*}"
 
 # Use files in the script directory by default


### PR DESCRIPTION
<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.github/workflows/build.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
